### PR TITLE
Make disappearingLogo more flexible about when it shows

### DIFF
--- a/src/main/components/video-overlays/disappearingLogo/DisappearingLogo.brs
+++ b/src/main/components/video-overlays/disappearingLogo/DisappearingLogo.brs
@@ -3,6 +3,12 @@ sub init()
     
     m.animation = m.top.findNode("fadeAnimation")
 
+    ' set default show and fade states
+    m.showStates = createObject("roArray", 1, true)
+    m.showStates.push("paused")
+    m.fadeStates = createObject("roArray", 1, true)
+    m.fadeStates.push("playing")
+
     ' setup timer to fade the logo
     m.timer = createObject("roSGNode", "Timer")
     m.timer.duration = m.top.displayTime
@@ -97,10 +103,12 @@ end sub
 
 sub showLogo(event as object)
     state = event.getData()
-    if state = "none" or state = "buffering" or state = "finished" or state = "error" then return
+    isShowLogo = arrayContainsValue(m.showStates, state)
+    isFadeLogo = arrayContainsValue(m.fadeStates, state)
+    if isShowLogo = false and isFadeLogo = false then return
     m.animation.control = "stop"
     m.logo.opacity = m.top.logoOpacity
-    if state = "playing" then
+    if isFadeLogo then
         m.timer.control = "start"
     end if
 end sub
@@ -112,3 +120,18 @@ end sub
 sub fieldsAreNotSet() as boolean
     return m.video = invalid or m.top.logoUri = invalid
 end sub
+
+function arrayContainsValue(array as object, value as string) as boolean
+    for each comparator in array
+        if comparator = value then return true
+    end for
+    return false
+end function
+
+function setShowStates(param as object) as object
+    m.showStates = param.states
+end function
+
+function setFadeStates(param as object) as object
+    m.fadeStates = param.states
+end function

--- a/src/main/components/video-overlays/disappearingLogo/DisappearingLogo.xml
+++ b/src/main/components/video-overlays/disappearingLogo/DisappearingLogo.xml
@@ -3,6 +3,8 @@
 <component name="DisappearingLogo" extends="Group" >
   <script type="text/brightscript" uri="pkg:/components/video-overlays/DisappearingLogo/DisappearingLogo.brs"/>
   <interface>
+    <function name="setShowStates" />
+    <function name="setFadeStates" />
     <field id = "logoUri" type = "uri" />
     <field id = "logoSize" type = "vector2d" />
     <field id = "logoOpacity" type = "float" value = "1" />

--- a/src/main/components/video-overlays/ratingIcon/RatingIcon.brs
+++ b/src/main/components/video-overlays/ratingIcon/RatingIcon.brs
@@ -8,6 +8,10 @@ sub init()
     m.logo.margin = m.top.margin
     m.logo.fixedPosition = m.top.fixedPosition
     m.logo.logoTranslation = m.top.logoTranslation
+    showParams = createObject("roAssociativeArray")
+    showStates = createObject("roArray", 1, true)
+    showParams.states = showStates
+    m.logo.callFunc("setShowStates", showParams)
 end sub
 
 ' A method called when the videoId is set

--- a/src/main/components/video-overlays/ratingIcon/RatingIcon.xml
+++ b/src/main/components/video-overlays/ratingIcon/RatingIcon.xml
@@ -5,8 +5,8 @@
   <interface>
     <field id = "iconFolderUri" type="uri" value="pkg:/images/ratingIcons" />
     <field id = "logoOpacity" type = "float" value = "1" onChange="setInnerField"/>
-    <field id = "displayTime" type = "float" value = "1" onChange="setInnerField"/>
-    <field id = "fadeTime" type = "float" value = "1" onChange="setInnerField"/>
+    <field id = "displayTime" type = "float" value = "50" onChange="setInnerField"/>
+    <field id = "fadeTime" type = "float" value = "10" onChange="setInnerField"/>
     <field id = "position" type = "string" value = "topLeft" onChange="setInnerField"/>
     <field id = "margin" type = "float" value = "10" onChange="setInnerField"/>
     <field id = "fixedPosition" type = "boolean" value = "false" onChange="setInnerField"/>


### PR DESCRIPTION
Adds functions so that a user can set when the disappearing logo shows up again and when it fades. This makes it so that the ratingIcon does not reappear when the video is paused. It does, however, reappear when the video starts playing again after a pause, which should probably be changed in a future PR. 